### PR TITLE
Fix Dockerfile for backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # Multi-stage build
 FROM python:3.11-slim AS builder
 WORKDIR /app
-COPY requirements.txt .
-RUN pip install --prefix=/install -r requirements.txt
+COPY backend/requirements.txt ./backend/requirements.txt
+RUN pip install --prefix=/install -r backend/requirements.txt
 
 FROM python:3.11-slim
 WORKDIR /app
 COPY --from=builder /install /usr/local
 COPY . .
-CMD ["python", "app.py"]
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
## Summary
- install backend requirements instead of root requirements
- run FastAPI app via uvicorn

## Testing
- `pip install -r backend/requirements.txt` *(fails: Getting requirements to build wheel did not run successfully)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684ab1b7220083229a284bf78dac8dd8