### PR TITLE
Add httpx and anyio to backend requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,5 @@ python-dotenv==1.0.0
 upstash-redis==0.15.0
 numpy==1.24.3
 sqlite-utils==3.35.0
+httpx==0.24.1
+anyio>=3,<4


### PR DESCRIPTION
## Summary
- add `httpx==0.24.1` and `anyio>=3,<4` to `backend/requirements.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ab1b9bb8483229ca3af9b399c7cd6