### PR TITLE
Add install and run helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ instructions for running the project locally and deploying it to the cloud.
 2. **Install dependencies**
 
    ```bash
-   npm install
+   ./install.sh
    ```
 
 3. **Create a `.env` file** with the required environment variables. Common
@@ -29,13 +29,15 @@ instructions for running the project locally and deploying it to the cloud.
 4. **Run the backend locally**
 
    ```bash
-   npm run dev
+   ./run.sh
    ```
 
-   Once running, you can check the health endpoint:
+   The script will start a local Redis instance if `redis-server` is available
+   and then launch the API with Uvicorn. Once running, you can check the health
+   endpoint:
 
    ```bash
-   curl http://localhost:3000/health
+   curl http://localhost:8000/health
    ```
 
 ## Deploying the Backend to Railway

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Upgrade pip and install dependencies for the backend
+python3 -m pip install --upgrade pip
+python3 -m pip install -r backend/requirements.txt

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start Redis if available
+if command -v redis-server >/dev/null 2>&1; then
+  echo "Starting redis-server..."
+  redis-server --daemonize yes
+else
+  echo "redis-server not found; continuing without it." >&2
+fi
+
+# Launch the FastAPI app using uvicorn
+exec uvicorn backend.main:app --host 0.0.0.0 --port "${PORT:-8000}"


### PR DESCRIPTION
## Summary
- add `install.sh` to install python deps from `backend/requirements.txt`
- add `run.sh` that optionally starts Redis and launches Uvicorn
- document new scripts in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ab1bb2ed08322868f513d42a405c4