### PR TITLE
Integrate LightVectorDB in chat backend

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,15 +1,37 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
 
+import json
+from pathlib import Path
+
 from backend.services.llm import RobustLLMClient
 from backend.services.embedding import load_embedding_model
 from backend.services.redis_client import get_redis_client
+from backend.services.vector_store import LightVectorDB
 
 app = FastAPI()
 
 llm_client = RobustLLMClient()
 embedding_model = load_embedding_model()
 redis_client = get_redis_client()
+vector_db = LightVectorDB()
+
+
+def _load_initial_embeddings() -> None:
+    """Load sample documents and store embeddings if DB is empty."""
+    if vector_db.count_documents() > 0:
+        return
+    data_path = Path(__file__).resolve().parent.parent / "data" / "documents.json"
+    with open(data_path, "r", encoding="utf-8") as f:
+        docs = json.load(f)
+    texts = [d.get("content", "") for d in docs]
+    embeddings = [embedding_model(text) for text in texts]
+    vector_db.add_documents(texts, embeddings)
+
+
+@app.on_event("startup")
+def startup_event():
+    _load_initial_embeddings()
 
 
 class ChatRequest(BaseModel):
@@ -23,5 +45,10 @@ def health():
 
 @app.post("/chat")
 def chat(req: ChatRequest):
+    query_embedding = embedding_model(req.message)
+    results = vector_db.similarity_search(query_embedding)
     response = llm_client.generate(req.message)
-    return {"response": response}
+    return {
+        "response": response,
+        "results": [{"text": text, "score": score} for text, score in results],
+    }

--- a/backend/services/vector_store.py
+++ b/backend/services/vector_store.py
@@ -35,6 +35,15 @@ class LightVectorDB:
         finally:
             conn.close()
 
+    def count_documents(self) -> int:
+        """Return the number of stored documents."""
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cursor = conn.execute("SELECT COUNT(*) FROM documents")
+            return cursor.fetchone()[0]
+        finally:
+            conn.close()
+
     def _cosine_similarity(self, a: List[float], b: List[float]) -> float:
         dot = sum(x * y for x, y in zip(a, b))
         norm_a = math.sqrt(sum(x * x for x in a))


### PR DESCRIPTION
## Summary
- persist embeddings with `LightVectorDB`
- bootstrap DB with example documents on startup
- use stored vectors in `/chat` endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684ab1c2a5808322a6d4033619b8bf67