### PR TITLE
Improve frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,6 @@ tutorialspoint.com
 Le serveur écoute par défaut sur 127.0.0.1:8000. Une fois lancé, l’API est accessible sur http://127.0.0.1:8000 et la documentation interactive Swagger est disponible sur http://127.0.0.1:8000/docs
 tutorialspoint.com
 .
+
+## Frontend
+Pour utiliser l'interface web simplifiee, ouvrez `frontend/index.html` dans votre navigateur une fois le serveur demarre.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,36 @@
+const historyEl = document.getElementById('history');
+
+async function send() {
+    const input = document.getElementById('message');
+    const msg = input.value.trim();
+    if (!msg) return;
+    appendMessage('user', msg);
+    input.value = '';
+
+    try {
+        const res = await fetch('/chat', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({message: msg})
+        });
+        const data = await res.json();
+        appendMessage('bot', data.reply || data.response);
+    } catch (err) {
+        appendMessage('bot', 'Error: ' + err.message);
+    }
+}
+
+function appendMessage(role, text) {
+    const div = document.createElement('div');
+    div.className = `message ${role}`;
+    div.textContent = text;
+    historyEl.appendChild(div);
+    historyEl.scrollTop = historyEl.scrollHeight;
+}
+
+document.getElementById('send-button').addEventListener('click', send);
+document.getElementById('message').addEventListener('keyup', (e) => {
+    if (e.key === 'Enter') {
+        send();
+    }
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,26 +3,16 @@
 <head>
     <meta charset="utf-8">
     <title>Archibot</title>
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <h1>Archibot</h1>
-    <div>
+    <div id="history"></div>
+    <div id="input-area">
         <input type="text" id="message" placeholder="Ask something" />
-        <button onclick="send()">Send</button>
+        <button id="send-button">Send</button>
     </div>
-    <pre id="response"></pre>
 
-    <script>
-    async function send() {
-        const msg = document.getElementById('message').value;
-        const res = await fetch('/chat', {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({message: msg})
-        });
-        const data = await res.json();
-        document.getElementById('response').textContent = data.response;
-    }
-    </script>
+    <script src="app.js"></script>
 </body>
 </html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,54 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f5f5f5;
+    margin: 0;
+    padding: 20px;
+    color: #333;
+}
+
+h1 {
+    text-align: center;
+    margin-bottom: 20px;
+}
+
+#history {
+    background: #fff;
+    border: 1px solid #ccc;
+    height: 300px;
+    overflow-y: auto;
+    padding: 10px;
+    margin-bottom: 20px;
+    display: flex;
+    flex-direction: column;
+}
+
+.message {
+    margin: 5px 0;
+    padding: 8px 12px;
+    border-radius: 4px;
+    max-width: 80%;
+}
+
+.message.user {
+    background: #e0f7fa;
+    align-self: flex-end;
+}
+
+.message.bot {
+    background: #e8eaf6;
+    align-self: flex-start;
+}
+
+#input-area {
+    display: flex;
+}
+
+#message {
+    flex: 1;
+    padding: 8px;
+}
+
+button {
+    padding: 8px 16px;
+    margin-left: 10px;
+}


### PR DESCRIPTION
## Summary
- style modern chat interface
- move JS to app.js for history scrolling
- load assets in HTML
- mention opening index.html in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684acf348abc8322bca4588a7779c95a