### PR TITLE
Update install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ Option 2 (pip) : installez manuellement les dépendances avec pip :
 bash
 Copier
 Modifier
-pip install -r requirements.txt
-La commande pip install -r requirements.txt installe toutes les bibliothèques listées dans ce fichier
+pip install -r backend/requirements.txt
+La commande pip install -r backend/requirements.txt installe toutes les bibliothèques listées dans ce fichier.
+Exécutez-la depuis la racine du projet.
 pip.pypa.io
 .
 Exécution


### PR DESCRIPTION
## Summary
- update the pip install command for manual setup
- note that the command should be run from the project root

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r backend/requirements.txt` *(fails: setuptools build errors)*

------
https://chatgpt.com/codex/tasks/task_e_684acfc435588322bf343f2825d16058