### PR TITLE
Fix README formatting and env variable notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,14 @@ python3 -m venv venv
 source venv/bin/activate   # on Windows: venv\Scripts\activate
 Installation
 Install the dependencies from backend/requirements.txt:
-
-bash
-Copier
-Modifier
+```bash
 pip install -r backend/requirements.txt
+```
 Running the Backend
 Start the FastAPI server with Uvicorn:
-
-bash
-Copier
-Modifier
+```bash
 uvicorn backend.main:app --reload
+```
 This command launches the ASGI server and imports the app from backend/main.py.
 The --reload option enables auto-reload on file changes.
 
@@ -35,33 +31,27 @@ You can either:
 Open frontend/index.html directly in your browser
 
 Or serve it via FastAPI with:
-
-python
-Copier
-Modifier
+```python
 from fastapi.staticfiles import StaticFiles
 app.mount("/", StaticFiles(directory="frontend", html=True), name="static")
+```
 Then open http://127.0.0.1:8000 to interact with the /chat endpoint.
 
 Health Check
 You can confirm the backend is running by executing:
-
-bash
-Copier
-Modifier
+```bash
 curl http://127.0.0.1:8000/health
+```
 Running Tests
 Run unit tests using:
-
-bash
-Copier
-Modifier
+```bash
 pytest
+```
 Environment Variables
 The application relies on several environment variables when deployed.
-An example configuration is provided in .env.example.
+An example configuration is provided in `.env.example`.
 
-PORT – port for the server (default: 8080)
+PORT – port for the server (default: 8000)
 
 REDIS_URL – address of the Redis instance used by the backend
 
@@ -71,4 +61,4 @@ GROQ_API_KEY, TOGETHER_API_KEY – for external LLMs
 
 UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN – credentials if using Upstash Redis
 
-Set these variables in your Railway project or local
+Set these variables in your Railway project or local environment using a `.env` file or by exporting them in your shell.


### PR DESCRIPTION
## Summary
- clean up formatting in `README.md`
- document where to set environment variables
- ensure instructions use `uvicorn backend.main:app --reload`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r backend/requirements.txt` *(fails: BackendUnavailable: Cannot import 'setuptools.build_meta')*

------
https://chatgpt.com/codex/tasks/task_e_684aebe442fc8322b9ffe813ea0cf368