### PR TITLE
Fix imports in backend tests

### DIFF
--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,5 +1,5 @@
 from fastapi.testclient import TestClient
-from backend.app.main import app, vector_db
+from backend.main import app, vector_db
 
 
 def create_client():


### PR DESCRIPTION
## Summary
- fix API tests to import from `backend.main`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aed238dc88322902526bb85ef4e3b