### PR TITLE
Switch backend embeddings to FastEmbed

### DIFF
--- a/backend/services/embedding.py
+++ b/backend/services/embedding.py
@@ -1,21 +1,25 @@
-from typing import Callable
+"""Utility for loading an embedding model."""
 
-try:
-    from sentence_transformers import SentenceTransformer
+from typing import Iterable, List
+
+try:  # pragma: no cover - optional dependency during tests
+    from fastembed import TextEmbedding
 except ImportError:  # pragma: no cover
-    SentenceTransformer = None
+    TextEmbedding = None
 
 
-def load_embedding_model(model_name: str = "all-MiniLM-L6-v2") -> Callable[[str], list]:
-    """Load a sentence transformer model or return a fallback embedder."""
-    if SentenceTransformer is None:
-        def dummy_embed(text: str):
-            return [len(text)]
-        return dummy_embed
+class _DummyEmbedder:
+    """Fallback embedder used when fastembed is unavailable."""
+
+    def embed(self, texts: Iterable[str]) -> List[List[float]]:
+        return [[float(len(t))] for t in texts]
+
+
+def load_embedding_model(model_name: str = "BAAI/bge-base-en-v1.5"):
+    """Load a fastembed TextEmbedding model or return a dummy embedder."""
+    if TextEmbedding is None:
+        return _DummyEmbedder()
     try:
-        model = SentenceTransformer(model_name)
-        return lambda text: model.encode(text).tolist()  # ensure JSON serializable
-    except Exception:
-        def dummy_embed(text: str):
-            return [len(text)]
-        return dummy_embed
+        return TextEmbedding(model_name=model_name)
+    except Exception:  # pragma: no cover - on failure use dummy model
+        return _DummyEmbedder()


### PR DESCRIPTION
## Summary
- use FastEmbed for text embeddings
- batch compute embeddings in `_load_initial_embeddings`
- adjust chat endpoint to fetch FastEmbed embeddings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aef9b01608322a0e5da3f69249ba4