### PR TITLE
Add backend url config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ app.mount("/", StaticFiles(directory="frontend", html=True), name="static")
 ```
 Then open http://127.0.0.1:8000 to interact with the /chat endpoint.
 
+If the frontend and backend are deployed separately, set the backend's
+URL for the JavaScript client. Define a `BACKEND_URL` environment
+variable during your build or include a script tag before `app.js` that
+sets `window.BACKEND_URL`:
+
+```html
+<script>
+  window.BACKEND_URL = 'https://your-backend.example.com';
+</script>
+```
+
 Health Check
 You can confirm the backend is running by executing:
 ```bash
@@ -64,5 +75,7 @@ GROQ_API_KEY, TOGETHER_API_KEY – keys for external LLMs
   then Together.ai if their keys are present.
 
 UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN – credentials if using Upstash Redis
+
+BACKEND_URL – base URL for the chat backend when the frontend is served separately
 
 Set these variables in your Railway project or local environment using a `.env` file or by exporting them in your shell.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -8,6 +8,11 @@ function appendMessage(text, type) {
     historyEl.scrollTop = historyEl.scrollHeight;
 }
 
+const backendUrl =
+    (typeof process !== 'undefined' && process.env && process.env.BACKEND_URL) ||
+    window.BACKEND_URL ||
+    '';
+
 async function send() {
     const input = document.getElementById('message');
     const text = input.value.trim();
@@ -17,7 +22,7 @@ async function send() {
     input.value = '';
 
     try {
-        const res = await fetch('/chat', {
+        const res = await fetch(`${backendUrl}/chat`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ message: text })


### PR DESCRIPTION
## Summary
- let the frontend fetch `/chat` via a configurable backend URL
- document how to set BACKEND_URL for separate deployments

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684af1279a6483228d4f3804c2a91681