### PR TITLE
Fix README install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Capable d'ingérer vos documents et de répondre à vos questions grâce à un s
 - **Builder** : `Nixpacks` *(ou Railway Build bêta)*
 - **Build command** :
   ```bash
-  pip install -r backend/requirements.txt
+  pip install -r requirements.txt
 Start command :
 
 bash


### PR DESCRIPTION
## Summary
- fix Python install instructions in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b580bac688322ba91dcd5b67d0616