### PR TITLE
Add production CORS config

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -24,7 +24,7 @@ app = FastAPI(lifespan=lifespan)
 # CORS middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # En prod: spécifier les domaines autorisés
+    allow_origins=["https://votre-domaine.com"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/readme.md
+++ b/readme.md
@@ -155,6 +155,8 @@ pip install -r requirements.txt
 uvicorn backend.main:app --host 0.0.0.0 --port $PORT
 ```
 
+> **Note:** mettez à jour `allow_origins` dans `backend/main.py` avec votre domaine de production (ex. `https://votre-domaine.com`) pour activer le CORS.
+
 ## 🧪 **Tests des endpoints**
 
 ### Test de santé


### PR DESCRIPTION
## Summary
- configure `allow_origins` for production
- mention CORS domain setup in deployment docs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b7266a2548322b6ddc6b52e39181d