### PR TITLE
Improve LLM error handling

### DIFF
--- a/backend/tests/test_llm.py
+++ b/backend/tests/test_llm.py
@@ -1,6 +1,8 @@
 import importlib
 
 from backend.services import llm
+from fastapi import HTTPException
+import logging
 
 
 def _fake_post(url, json, headers, timeout=10):
@@ -47,3 +49,41 @@ def test_no_keys(monkeypatch):
     monkeypatch.setattr(llm, "openai", None)
     client = llm.RobustLLMClient()
     assert client.generate("hi") == "No LLM API key configured."
+
+
+def test_openai_error(monkeypatch, caplog):
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    monkeypatch.delenv("TOGETHER_API_KEY", raising=False)
+    importlib.reload(llm)
+    class FakeOpenAI:
+        class ChatCompletion:
+            @staticmethod
+            def create(*args, **kwargs):
+                raise RuntimeError("boom")
+    monkeypatch.setattr(llm, "openai", FakeOpenAI)
+    client = llm.RobustLLMClient()
+    with caplog.at_level(logging.ERROR):
+        resp = client.generate("hi")
+    assert resp == "LLM request failed"
+    assert "boom" in caplog.text
+
+
+def test_raise_http_exception(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    monkeypatch.delenv("TOGETHER_API_KEY", raising=False)
+    importlib.reload(llm)
+    class FakeOpenAI:
+        class ChatCompletion:
+            @staticmethod
+            def create(*args, **kwargs):
+                raise RuntimeError("boom")
+    monkeypatch.setattr(llm, "openai", FakeOpenAI)
+    client = llm.RobustLLMClient()
+    try:
+        client.generate("hi", raise_http=True)
+    except HTTPException as exc:
+        assert exc.status_code == 500
+    else:  # pragma: no cover
+        assert False, "HTTPException not raised"


### PR DESCRIPTION
## Summary
- log LLM failures instead of returning the raw exception
- add optional HTTPException raising in `generate`
- test error and raising paths for LLM client

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b793b5364832295d589fb57257b08