### PR TITLE
Configure logging in FastAPI app

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
 import json
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- configure Python logging in backend app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b7ccf02f08322b529e60f32426f2d