### PR TITLE
Sanitize placeholder in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 PORT=8080
 OPENAI_API_KEY=your_openai_key_here
-GROQ_API_KEY=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
+GROQ_API_KEY=gsk_your_key_here
 TOGETHER_API_KEY=your_together_key_here


### PR DESCRIPTION
## Summary
- sanitize `.env.example` by replacing the real `GROQ_API_KEY`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b99fc30088322ae391ea9295d8aba