### PR TITLE
Make allowed origins configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ PORT=8080
 OPENAI_API_KEY=your_openai_key_here
 GROQ_API_KEY=gsk_your_key_here
 TOGETHER_API_KEY=your_together_key_here
+ALLOWED_ORIGINS=https://your-domain.com

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
+import os
 
 import logging
 
@@ -26,9 +27,15 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 
 # CORS middleware
+_origins_env = os.getenv("ALLOWED_ORIGINS")
+if _origins_env:
+    _allowed_origins = [o.strip() for o in _origins_env.split(",")]
+else:  # development default
+    _allowed_origins = ["*"]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["https://your-domain.com"],
+    allow_origins=_allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/readme.md
+++ b/readme.md
@@ -138,6 +138,7 @@ uvicorn backend.main:app --reload
 | `GROQ_API_KEY` | Clé API Groq | ⚠️ | `gsk_...` |
 | `TOGETHER_API_KEY` | Clé API Together | ⚠️ | `...` |
 | `REDIS_URL` | URL Redis | ❌ | Auto |
+| `ALLOWED_ORIGINS` | Origines CORS autorisées (séparées par des virgules) | ❌ | `https://your-domain.com` |
 
 ### Commandes de build
 
@@ -149,7 +150,7 @@ python -m pip install --no-cache-dir -r requirements.txt
 uvicorn backend.main:app --host 0.0.0.0 --port $PORT
 ```
 
-> **Note:** mettez à jour `allow_origins` dans `backend/main.py` avec votre domaine de production (ex. `https://your-domain.com`) pour activer le CORS.
+> **Note:** utilisez la variable `ALLOWED_ORIGINS` pour configurer le CORS (ex. `https://your-domain.com`).
 
 ## 🧪 **Tests des endpoints**
 


### PR DESCRIPTION
## Summary
- support `ALLOWED_ORIGINS` env var for CORS config
- document `ALLOWED_ORIGINS` usage
- add placeholder value in `.env.example`

## Testing
- `pip install --quiet --no-cache-dir -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b9c70f000832282bb7b0c4ca8ee9a