### PR TITLE
Include search context in LLM prompt

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -85,7 +85,9 @@ def chat(req: ChatRequest):
     if hasattr(query_embedding, "tolist"):
         query_embedding = query_embedding.tolist()
     results = vector_db.similarity_search(query_embedding)
-    response = llm_client.generate(req.message)
+    context = " ".join(text for text, _ in results)
+    prompt = f"Context: {context} Question: {req.message}"
+    response = llm_client.generate(prompt)
     return {
         "response": response,
         "results": [{"text": text, "score": score} for text, score in results],

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -14,8 +14,17 @@ def test_health():
         assert response.json() == {"status": "ok"}
         assert vector_db.count_documents() > 0
 
-def test_chat():
-    """Test /chat endpoint returns a valid response and search results."""
+def test_chat(monkeypatch):
+    """Test /chat endpoint returns a valid response and uses docs in the prompt."""
+    captured = {}
+
+    def fake_generate(prompt: str):
+        captured["prompt"] = prompt
+        return "ok"
+
+    import backend.main as main
+    monkeypatch.setattr(main.llm_client, "generate", fake_generate)
+
     with create_client() as client:
         payload = {"message": "hello"}
         response = client.post("/chat", json=payload)
@@ -31,6 +40,11 @@ def test_chat():
         if data["results"]:
             assert "text" in data["results"][0]
             assert "score" in data["results"][0]
+
+    assert "Context:" in captured["prompt"]
+    assert "Question: hello" in captured["prompt"]
+    if data["results"]:
+        assert data["results"][0]["text"] in captured["prompt"]
 
 
 def test_no_redis_client_variable():


### PR DESCRIPTION
## Summary
- build a single prompt containing the top documents and the question
- check that `/chat` uses the docs when invoking `generate`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b9da4f6c483229a836810197235d2