### PR TITLE
Fix chat endpoint docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -165,7 +165,7 @@ curl https://your-app.railway.app/health
 curl -X POST https://your-app.railway.app/chat \
   -H "Content-Type: application/json" \
   -d '{
-    "prompt": "Quelle est la hauteur maximale autorisée en zone urbaine ?"
+    "message": "Quelle est la hauteur maximale autorisée en zone urbaine ?"
   }'
 ```
 
@@ -195,7 +195,7 @@ archibot-light/
 ### POST `/chat`
 ```json
 {
-  "prompt": "Votre question",
+  "message": "Votre question",
   "context": "Contexte optionnel",
   "model": "gpt-4" // optionnel
 }


### PR DESCRIPTION
## Summary
- update chat endpoint examples to use `message`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ba2cde4f48322b1e8b672bafc103d